### PR TITLE
NumericManaHUD

### DIFF
--- a/src/main/java/de/sarenor/arsinstrumentum/ArsInstrumentum.java
+++ b/src/main/java/de/sarenor/arsinstrumentum/ArsInstrumentum.java
@@ -1,11 +1,14 @@
 package de.sarenor.arsinstrumentum;
 
 import de.sarenor.arsinstrumentum.network.Networking;
+import de.sarenor.arsinstrumentum.setup.ArsInstrumentumConfig;
 import de.sarenor.arsinstrumentum.setup.Registration;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -18,6 +21,7 @@ public class ArsInstrumentum {
 
     public ArsInstrumentum() {
         IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
+        ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ArsInstrumentumConfig.CLIENT_SPEC);
         Registration.init(bus);
         bus.addListener(this::setup);
         bus.addListener(this::doClientStuff);

--- a/src/main/java/de/sarenor/arsinstrumentum/client/NumericManaHUD.java
+++ b/src/main/java/de/sarenor/arsinstrumentum/client/NumericManaHUD.java
@@ -1,0 +1,86 @@
+package de.sarenor.arsinstrumentum.client;
+
+import com.hollingsworth.arsnouveau.ArsNouveau;
+import com.hollingsworth.arsnouveau.api.client.IDisplayMana;
+import com.hollingsworth.arsnouveau.api.mana.IManaCap;
+import com.hollingsworth.arsnouveau.common.capability.CapabilityRegistry;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.PoseStack;
+import de.sarenor.arsinstrumentum.ArsInstrumentum;
+import de.sarenor.arsinstrumentum.items.curios.NumericCharm;
+import de.sarenor.arsinstrumentum.setup.ArsInstrumentumConfig.Client;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiComponent;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * @implNote Credits to Moonwolf287 for original implementation
+ * @link <a href="https://github.com/Moonwolf287/ArsEnderStorage/blob/1.16.5/src/main/java/io/github/moonwolf287/ars_enderstorage/ManaTextGUI.java">Original implementation in 1.16.5</a>
+ */
+@SuppressWarnings("ALL")
+@Mod.EventBusSubscriber(value = Dist.CLIENT, modid = ArsInstrumentum.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+public class NumericManaHUD extends GuiComponent {
+    private static final Minecraft minecraft = Minecraft.getInstance();
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public static void renderSpellHUD(final RenderGameOverlayEvent.Post event) {
+        Player player = minecraft.player;
+        if (event.getType() != RenderGameOverlayEvent.ElementType.ALL || player == null ||
+                Boolean.FALSE.equals(Client.SHOW_MANA_NUM.get())) {
+            return;
+        }
+        if (NumericCharm.hasCharm(player)){
+            drawHUD(event.getMatrixStack(), player);
+        }
+    }
+
+    public static boolean shouldDisplayBar() {
+        if (minecraft.player == null) return false;
+        ItemStack mainHand = minecraft.player.getMainHandItem();
+        ItemStack offHand = minecraft.player.getOffhandItem();
+        return mainHand.getItem() instanceof IDisplayMana item && item.shouldDisplay(mainHand) || offHand.getItem() instanceof IDisplayMana item2 && item2.shouldDisplay(offHand);
+    }
+
+    private static void drawHUD(PoseStack ms, Player player) {
+
+        IManaCap mana = CapabilityRegistry.getMana(player).orElse(null);
+
+        if (!shouldDisplayBar() || mana == null) {
+            return;
+        }
+
+        boolean renderOnTop = Client.SHOW_MANA_ON_TOP.get();
+
+        int offsetLeft = 10;
+        int height = minecraft.getWindow().getGuiScaledHeight() - 15;
+        int max = mana.getMaxMana();
+        int current = (int) mana.getCurrentMana();
+        String delimiter = renderOnTop ? "/" : "   /   ";
+
+        String textMax = max + delimiter + max;
+        String text = current + delimiter + max;
+
+        int maxWidth = minecraft.font.width(textMax);
+        if (renderOnTop) {
+            height -= 25;
+        } else {
+            offsetLeft = 67 - maxWidth / 2;
+        }
+        offsetLeft += maxWidth - minecraft.font.width(text);
+
+        drawString(ms, minecraft.font, text, offsetLeft, height, 0xFFFFFF);
+        if (!renderOnTop) {
+            RenderSystem.setShaderTexture(0, new ResourceLocation(ArsNouveau.MODID, "textures/gui/manabar_gui_border" + ".png"));
+            blit(ms, 10, height - 8, 0, 18, 108, 20, 256, 256);
+        }
+
+    }
+
+}

--- a/src/main/java/de/sarenor/arsinstrumentum/datagen/LanguageProvider.java
+++ b/src/main/java/de/sarenor/arsinstrumentum/datagen/LanguageProvider.java
@@ -1,12 +1,11 @@
 package de.sarenor.arsinstrumentum.datagen;
 
 import de.sarenor.arsinstrumentum.ArsInstrumentum;
-import de.sarenor.arsinstrumentum.setup.Registration;
 import lombok.extern.log4j.Log4j2;
 import net.minecraft.data.DataGenerator;
 
-import static de.sarenor.arsinstrumentum.client.keybindings.ModKeyBindings.CHOOSE_ARMARIUM_SLOT_ID;
-import static de.sarenor.arsinstrumentum.client.keybindings.ModKeyBindings.SWITCH_ARMARIUM_SLOT_ID;
+import static de.sarenor.arsinstrumentum.client.keybindings.ModKeyBindings.*;
+import static de.sarenor.arsinstrumentum.setup.Registration.*;
 
 @Log4j2
 public class LanguageProvider extends net.minecraftforge.common.data.LanguageProvider {
@@ -19,13 +18,14 @@ public class LanguageProvider extends net.minecraftforge.common.data.LanguagePro
     @Override
     protected void addTranslations() {
         log.info("ArsInstrumentum: AddTranslation started");
-        add(Registration.WIZARDS_ARMARIUM.get(), "Wizards Armarium");
-        add(Registration.SCROLL_OF_SAVE_STARBUNCLE.get(), "Scroll of Save Starbuncle");
-        add(Registration.RUNIC_STORAGE_STONE.get(), "Runic Stone of Storage");
-        add(Registration.FAKE_WILDEN_TRIBUTE.get(), "Essence of Vanquished Foes");
-        add(Registration.COPY_PASTE_SPELL_SCROLL.get(), "Scroll of Spelltransfer");
+        add(WIZARDS_ARMARIUM.get(), "Wizards Armarium");
+        add(SCROLL_OF_SAVE_STARBUNCLE.get(), "Scroll of Save Starbuncle");
+        add(RUNIC_STORAGE_STONE.get(), "Runic Stone of Storage");
+        add(FAKE_WILDEN_TRIBUTE.get(), "Essence of Vanquished Foes");
+        add(COPY_PASTE_SPELL_SCROLL.get(), "Scroll of Spelltransfer");
         add(SWITCH_ARMARIUM_SLOT_ID, "Switch Wizards Armarium");
         add(CHOOSE_ARMARIUM_SLOT_ID, "(Wizards Armarium) Toggle Selection HUD");
+        add(NUMERIC_CHARM.get(), "Charm of Numeric Mana");
         log.info("ArsInstrumentum: AddTranslation ended");
     }
 }

--- a/src/main/java/de/sarenor/arsinstrumentum/items/curios/NumericCharm.java
+++ b/src/main/java/de/sarenor/arsinstrumentum/items/curios/NumericCharm.java
@@ -1,0 +1,30 @@
+package de.sarenor.arsinstrumentum.items.curios;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraftforge.items.IItemHandlerModifiable;
+import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.type.capability.ICurioItem;
+
+public class NumericCharm extends Item implements ICurioItem {
+    public NumericCharm(Properties pProperties) {
+        super(pProperties);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    public static boolean hasCharm(Player player) {
+
+        IItemHandlerModifiable items = CuriosApi.getCuriosHelper().getEquippedCurios(player).orElse(null);
+        //Blame Bailey for this @NotNull infringement
+        if (items != null) {
+            for(int i = 0; i < items.getSlots(); ++i) {
+                Item item = items.getStackInSlot(i).getItem();
+                if (item instanceof NumericCharm) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/de/sarenor/arsinstrumentum/setup/ArsInstrumentumConfig.java
+++ b/src/main/java/de/sarenor/arsinstrumentum/setup/ArsInstrumentumConfig.java
@@ -1,11 +1,27 @@
 package de.sarenor.arsinstrumentum.setup;
 
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.fml.common.Mod;
+import org.apache.commons.lang3.tuple.Pair;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.event.config.ModConfigEvent;
 
 @Mod.EventBusSubscriber
 public class ArsInstrumentumConfig {
+
+    public static final Common COMMON;
+    public static final Client CLIENT;
+    public static final ForgeConfigSpec COMMON_SPEC;
+    public static final ForgeConfigSpec CLIENT_SPEC;
+
+    static {
+        final Pair<Common, ForgeConfigSpec> specPair = new ForgeConfigSpec.Builder().configure(Common::new);
+        COMMON_SPEC = specPair.getRight();
+        COMMON = specPair.getLeft();
+        final Pair<Client,ForgeConfigSpec> specClientPair = new ForgeConfigSpec.Builder().configure(Client::new);
+        CLIENT_SPEC = specClientPair.getRight();
+        CLIENT = specClientPair.getLeft();
+    }
 
     @SubscribeEvent
     public static void onLoad(final ModConfigEvent.Loading configEvent) {
@@ -14,4 +30,27 @@ public class ArsInstrumentumConfig {
     @SubscribeEvent
     public static void onReload(final ModConfigEvent.Reloading configEvent) {
     }
+
+    public static class Common{
+        public Common(ForgeConfigSpec.Builder builder){
+
+        }
+
+    }
+
+    public static class Client{
+
+        public static ForgeConfigSpec.BooleanValue SHOW_MANA_NUM;
+        public static ForgeConfigSpec.BooleanValue SHOW_MANA_ON_TOP;
+
+        public Client(ForgeConfigSpec.Builder builder) {
+
+            builder.push("Display mana amount numerical");
+            SHOW_MANA_NUM = builder.comment("Display numbers").define("showManaNumerical", true);
+            SHOW_MANA_ON_TOP = builder.comment("Display numbers above the bar instead of on it").define("displayAboveBar", false);
+            builder.pop();
+
+        }
+    }
+
 }

--- a/src/main/java/de/sarenor/arsinstrumentum/setup/Registration.java
+++ b/src/main/java/de/sarenor/arsinstrumentum/setup/Registration.java
@@ -5,6 +5,7 @@ import de.sarenor.arsinstrumentum.ArsInstrumentum;
 import de.sarenor.arsinstrumentum.items.CopyPasteSpellScroll;
 import de.sarenor.arsinstrumentum.items.RunicStorageStone;
 import de.sarenor.arsinstrumentum.items.ScrollOfSaveStarbuncle;
+import de.sarenor.arsinstrumentum.items.curios.NumericCharm;
 import de.sarenor.arsinstrumentum.items.curios.armarium.WizardsArmarium;
 import net.minecraft.world.item.Item;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -24,7 +25,14 @@ public class Registration {
     public static final RegistryObject<Item> COPY_PASTE_SPELL_SCROLL = ITEMS.register(CopyPasteSpellScroll.COPY_PASTE_SPELL_SCROLL, CopyPasteSpellScroll::new);
     public static final RegistryObject<Item> FAKE_WILDEN_TRIBUTE = ITEMS.register(FAKE_WILDEN_TRIBUTE_ID, () -> new Item(new Item.Properties().tab(ArsNouveau.itemGroup)));
 
+    public static final RegistryObject<Item> NUMERIC_CHARM; //choose one of the two styles, I usually divide to keep lines shorter
+
+    static {
+        NUMERIC_CHARM = ITEMS.register("numeric_mana_charm", () -> new NumericCharm(new Item.Properties().stacksTo(1).tab(ArsNouveau.itemGroup)));
+    }
+
     public static void init(IEventBus bus) {
         ITEMS.register(bus);
     }
+
 }

--- a/src/main/resources/data/curios/tags/items/charm.json
+++ b/src/main/resources/data/curios/tags/items/charm.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "ars_instrumentum:numeric_mana_charm"
+  ]
+}


### PR DESCRIPTION
While the NumericCharm is in the Charm slot, current and maximum mana numeric values are displayed over the mana bar. Can also be entirely disabled by config or moved over the mana bar. No textures included, refractor anything you don't like.
Credits to Moonwolf for the original code based on Bailey's hud code, all under LGPL License.