### PR TITLE
bundle data, update to Wilden API changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,4 @@ classes
 
 # Files from Forge MDK
 forge*changelog.txt
-src/generated/resources/.cache/cache
-src/generated
+/src/generated/resources/.cache/

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ mc_version=1.19.2
 forge_version=43.2.0
 jei_version=11.4.0.285
 curio_version=5.1.1.0
-ars_version=3.13.1.445
+ars_version=3.15.0.501

--- a/src/generated/resources/assets/ars_instrumentum/lang/en_us.json
+++ b/src/generated/resources/assets/ars_instrumentum/lang/en_us.json
@@ -1,0 +1,14 @@
+{
+  "ars_instrumentum.tooltip.mana_cost": "Mana cost : ",
+  "block.ars_instrumentum.arcane_applicator": "Arcane Applicator",
+  "instrumentum.armarium.hotbar_no_switch": "Wizards Armarium will not switch Hotbar Items",
+  "instrumentum.armarium.hotbar_switch": "Wizards Armarium will switch Hotbar Items",
+  "item.ars_instrumentum.copy_paste_spell_scroll": "Scroll of Spelltransfer",
+  "item.ars_instrumentum.fake_wilden_tribute": "Essence of Vanquished Foes",
+  "item.ars_instrumentum.numeric_mana_charm": "Charm of Numeric Mana",
+  "item.ars_instrumentum.runic_storage_stone": "Runic Stone of Storage",
+  "item.ars_instrumentum.scroll_of_save_starbuncle": "Scroll of Save Starbuncle",
+  "item.ars_instrumentum.wizards_armarium": "Wizards Armarium",
+  "key.ars_nouveau.choose_armarium_slot": "(Wizards Armarium) Toggle Selection HUD",
+  "key.ars_nouveau.switch_armarium_slot": "Switch Wizards Armarium"
+}

--- a/src/generated/resources/assets/ars_instrumentum/models/item/copy_paste_spell_scroll.json
+++ b/src/generated/resources/assets/ars_instrumentum/models/item/copy_paste_spell_scroll.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "ars_instrumentum:items/copy_paste_spell_scroll"
+  }
+}

--- a/src/generated/resources/assets/ars_instrumentum/models/item/fake_wilden_tribute.json
+++ b/src/generated/resources/assets/ars_instrumentum/models/item/fake_wilden_tribute.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "ars_instrumentum:items/fake_wilden_tribute"
+  }
+}

--- a/src/generated/resources/assets/ars_instrumentum/models/item/numeric_mana_charm.json
+++ b/src/generated/resources/assets/ars_instrumentum/models/item/numeric_mana_charm.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "ars_instrumentum:items/numeric_mana_charm"
+  }
+}

--- a/src/generated/resources/assets/ars_instrumentum/models/item/runic_storage_stone.json
+++ b/src/generated/resources/assets/ars_instrumentum/models/item/runic_storage_stone.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "ars_instrumentum:items/runic_storage_stone"
+  }
+}

--- a/src/generated/resources/assets/ars_instrumentum/models/item/scroll_of_save_starbuncle.json
+++ b/src/generated/resources/assets/ars_instrumentum/models/item/scroll_of_save_starbuncle.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "ars_instrumentum:items/scroll_of_save_starbuncle"
+  }
+}

--- a/src/generated/resources/assets/ars_instrumentum/models/item/wizards_armarium.json
+++ b/src/generated/resources/assets/ars_instrumentum/models/item/wizards_armarium.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "ars_instrumentum:items/wizards_armarium"
+  }
+}

--- a/src/generated/resources/data/ars_instrumentum/advancements/recipes/ars_nouveau/arcane_applicator.json
+++ b/src/generated/resources/data/ars_instrumentum/advancements/recipes/ars_nouveau/arcane_applicator.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_journal": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "ars_nouveau:worn_notebook"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "ars_instrumentum:arcane_applicator"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_journal",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "ars_instrumentum:arcane_applicator"
+    ]
+  }
+}

--- a/src/generated/resources/data/ars_instrumentum/advancements/recipes/ars_nouveau/copy_paste_spell_scroll.json
+++ b/src/generated/resources/data/ars_instrumentum/advancements/recipes/ars_nouveau/copy_paste_spell_scroll.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_journal": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "ars_nouveau:worn_notebook"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "ars_instrumentum:copy_paste_spell_scroll"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_journal",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "ars_instrumentum:copy_paste_spell_scroll"
+    ]
+  }
+}

--- a/src/generated/resources/data/ars_instrumentum/advancements/recipes/ars_nouveau/runic_storage_stone.json
+++ b/src/generated/resources/data/ars_instrumentum/advancements/recipes/ars_nouveau/runic_storage_stone.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_journal": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "ars_nouveau:worn_notebook"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "ars_instrumentum:runic_storage_stone"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_journal",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "ars_instrumentum:runic_storage_stone"
+    ]
+  }
+}

--- a/src/generated/resources/data/ars_instrumentum/advancements/recipes/ars_nouveau/runic_storage_stone_alternate.json
+++ b/src/generated/resources/data/ars_instrumentum/advancements/recipes/ars_nouveau/runic_storage_stone_alternate.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_journal": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "ars_nouveau:worn_notebook"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "ars_instrumentum:runic_storage_stone_alternate"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_journal",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "ars_instrumentum:runic_storage_stone_alternate"
+    ]
+  }
+}

--- a/src/generated/resources/data/ars_instrumentum/advancements/recipes/ars_nouveau/scroll_of_save_starbuncle.json
+++ b/src/generated/resources/data/ars_instrumentum/advancements/recipes/ars_nouveau/scroll_of_save_starbuncle.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_journal": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "ars_nouveau:worn_notebook"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "ars_instrumentum:scroll_of_save_starbuncle"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_journal",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "ars_instrumentum:scroll_of_save_starbuncle"
+    ]
+  }
+}

--- a/src/generated/resources/data/ars_instrumentum/loot_tables/blocks/arcane_applicator.json
+++ b/src/generated/resources/data/ars_instrumentum/loot_tables/blocks/arcane_applicator.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "ars_instrumentum:arcane_applicator"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/apprentice_boots_from_archmage.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/apprentice_boots_from_archmage.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:apprentice_boots"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:iron_boots"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:archmage_boots"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/apprentice_boots_from_novice.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/apprentice_boots_from_novice.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:apprentice_boots"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:iron_boots"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:novice_boots"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/apprentice_hood_from_archmage.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/apprentice_hood_from_archmage.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:apprentice_hood"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:iron_helmet"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:archmage_hood"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/apprentice_hood_from_novice.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/apprentice_hood_from_novice.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:apprentice_hood"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:iron_helmet"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:novice_hood"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/apprentice_leggings_from_archmage.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/apprentice_leggings_from_archmage.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:apprentice_leggings"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:iron_leggings"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:archmage_leggings"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/apprentice_leggings_from_novice.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/apprentice_leggings_from_novice.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:apprentice_leggings"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:iron_leggings"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:novice_leggings"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/apprentice_robes_from_archmage.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/apprentice_robes_from_archmage.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:apprentice_robes"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:iron_chestplate"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:archmage_robes"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/apprentice_robes_from_novice.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/apprentice_robes_from_novice.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:apprentice_robes"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:iron_chestplate"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:novice_robes"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/archmage_boots_from_apprentice.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/archmage_boots_from_apprentice.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:archmage_boots"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:diamond_boots"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:apprentice_boots"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/archmage_boots_from_novice.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/archmage_boots_from_novice.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:archmage_boots"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:diamond_boots"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:novice_boots"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/archmage_hood_from_apprentice.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/archmage_hood_from_apprentice.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:archmage_hood"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:diamond_helmet"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:apprentice_hood"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/archmage_hood_from_novice.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/archmage_hood_from_novice.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:archmage_hood"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:diamond_helmet"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:novice_hood"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/archmage_leggings_from_apprentice.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/archmage_leggings_from_apprentice.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:archmage_leggings"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:diamond_leggings"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:apprentice_leggings"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/archmage_leggings_from_novice.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/archmage_leggings_from_novice.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:archmage_leggings"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:diamond_leggings"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:novice_leggings"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/archmage_robes_from_apprentice.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/archmage_robes_from_apprentice.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:archmage_robes"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:diamond_chestplate"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:apprentice_robes"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/archmage_robes_from_novice.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/archmage_robes_from_novice.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:archmage_robes"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:diamond_chestplate"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:novice_robes"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/novice_boots_from_apprentice.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/novice_boots_from_apprentice.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:novice_boots"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:golden_boots"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:apprentice_boots"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/novice_boots_from_archmage.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/novice_boots_from_archmage.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:novice_boots"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:golden_boots"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:archmage_boots"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/novice_hood_from_apprentice.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/novice_hood_from_apprentice.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:novice_hood"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:golden_helmet"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:apprentice_hood"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/novice_hood_from_archmage.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/novice_hood_from_archmage.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:novice_hood"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:golden_helmet"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:archmage_hood"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/novice_leggings_from_apprentice.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/novice_leggings_from_apprentice.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:novice_leggings"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:golden_leggings"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:apprentice_leggings"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/novice_leggings_from_archmage.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/novice_leggings_from_archmage.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:novice_leggings"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:golden_leggings"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:archmage_leggings"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/novice_robes_from_apprentice.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/novice_robes_from_apprentice.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:novice_robes"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:golden_chestplate"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:apprentice_robes"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/novice_robes_from_archmage.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/novice_robes_from_archmage.json
@@ -1,0 +1,18 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": true,
+  "output": {
+    "item": "ars_nouveau:novice_robes"
+  },
+  "pedestalItems": [
+    {
+      "item": "minecraft:golden_chestplate"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:archmage_robes"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/numeric_mana_charm.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/numeric_mana_charm.json
@@ -1,0 +1,30 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": false,
+  "output": {
+    "item": "ars_instrumentum:numeric_mana_charm"
+  },
+  "pedestalItems": [
+    {
+      "tag": "forge:ingots/gold"
+    },
+    {
+      "tag": "forge:ingots/gold"
+    },
+    {
+      "item": "minecraft:diamond"
+    },
+    {
+      "item": "minecraft:ink_sac"
+    },
+    {
+      "item": "minecraft:paper"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:dull_trinket"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/apparatus/wizards_armarium.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/apparatus/wizards_armarium.json
@@ -1,0 +1,39 @@
+{
+  "type": "ars_nouveau:enchanting_apparatus",
+  "keepNbtOfReagent": false,
+  "output": {
+    "item": "ars_instrumentum:wizards_armarium"
+  },
+  "pedestalItems": [
+    {
+      "item": "ars_nouveau:magebloom_fiber"
+    },
+    {
+      "item": "ars_nouveau:magebloom_fiber"
+    },
+    {
+      "item": "minecraft:blaze_rod"
+    },
+    {
+      "item": "minecraft:blaze_rod"
+    },
+    {
+      "item": "minecraft:diamond"
+    },
+    {
+      "item": "minecraft:diamond"
+    },
+    {
+      "item": "minecraft:ender_chest"
+    },
+    {
+      "item": "ars_nouveau:manipulation_essence"
+    }
+  ],
+  "reagent": [
+    {
+      "item": "ars_nouveau:mundane_belt"
+    }
+  ],
+  "sourceCost": 0
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/arcane_applicator.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/arcane_applicator.json
@@ -1,0 +1,25 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "key": {
+    "A": {
+      "item": "ars_nouveau:archwood_slab"
+    },
+    "G": {
+      "tag": "forge:nuggets/gold"
+    },
+    "R": {
+      "tag": "forge:dusts/redstone"
+    },
+    "S": {
+      "item": "ars_nouveau:sourcestone"
+    }
+  },
+  "pattern": [
+    "GAG",
+    " S ",
+    "SRS"
+  ],
+  "result": {
+    "item": "ars_instrumentum:arcane_applicator"
+  }
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/copy_paste_spell_scroll.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/copy_paste_spell_scroll.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "ars_nouveau:blank_parchment"
+    },
+    {
+      "item": "ars_nouveau:source_gem"
+    },
+    {
+      "item": "minecraft:ink_sac"
+    },
+    {
+      "item": "minecraft:feather"
+    }
+  ],
+  "result": {
+    "item": "ars_instrumentum:copy_paste_spell_scroll"
+  }
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/imbuement/imbuement_fake_wilden_tribute.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/imbuement/imbuement_fake_wilden_tribute.json
@@ -1,0 +1,26 @@
+{
+  "type": "ars_nouveau:imbuement",
+  "count": 1,
+  "input": {
+    "tag": "forge:storage_blocks/diamond"
+  },
+  "output": "ars_instrumentum:fake_wilden_tribute",
+  "pedestalItems": [
+    {
+      "item": {
+        "item": "ars_nouveau:archmage_spell_book"
+      }
+    },
+    {
+      "item": {
+        "item": "minecraft:nether_star"
+      }
+    },
+    {
+      "item": {
+        "item": "minecraft:totem_of_undying"
+      }
+    }
+  ],
+  "source": 5000
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/runic_storage_stone.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/runic_storage_stone.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "ars_nouveau:source_gem"
+    },
+    {
+      "item": "minecraft:lapis_lazuli"
+    },
+    {
+      "item": "minecraft:flint"
+    }
+  ],
+  "result": {
+    "item": "ars_instrumentum:runic_storage_stone"
+  }
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/runic_storage_stone_alternate.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/runic_storage_stone_alternate.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "ars_instrumentum:runic_storage_stone"
+    }
+  ],
+  "result": {
+    "item": "ars_instrumentum:runic_storage_stone"
+  }
+}

--- a/src/generated/resources/data/ars_instrumentum/recipes/scroll_of_save_starbuncle.json
+++ b/src/generated/resources/data/ars_instrumentum/recipes/scroll_of_save_starbuncle.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "ars_nouveau:blank_parchment"
+    },
+    {
+      "tag": "forge:nuggets/gold"
+    },
+    {
+      "item": "minecraft:ink_sac"
+    },
+    {
+      "item": "minecraft:feather"
+    }
+  ],
+  "result": {
+    "count": 2,
+    "item": "ars_instrumentum:scroll_of_save_starbuncle"
+  }
+}

--- a/src/generated/resources/data/minecraft/tags/blocks/mineable/axe.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/mineable/axe.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "ars_instrumentum:arcane_applicator"
+  ]
+}

--- a/src/generated/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "ars_instrumentum:arcane_applicator"
+  ]
+}

--- a/src/main/java/de/sarenor/arsinstrumentum/client/NumericManaHUD.java
+++ b/src/main/java/de/sarenor/arsinstrumentum/client/NumericManaHUD.java
@@ -1,17 +1,15 @@
 package de.sarenor.arsinstrumentum.client;
 
-import com.hollingsworth.arsnouveau.ArsNouveau;
+import com.hollingsworth.arsnouveau.api.ArsNouveauAPI;
 import com.hollingsworth.arsnouveau.api.client.IDisplayMana;
 import com.hollingsworth.arsnouveau.api.mana.IManaCap;
 import com.hollingsworth.arsnouveau.common.capability.CapabilityRegistry;
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import de.sarenor.arsinstrumentum.ArsInstrumentum;
 import de.sarenor.arsinstrumentum.items.curios.NumericCharm;
 import de.sarenor.arsinstrumentum.setup.ArsInstrumentumConfig.Client;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiComponent;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
@@ -57,29 +55,24 @@ public class NumericManaHUD extends GuiComponent {
 
         boolean renderOnTop = Client.SHOW_MANA_ON_TOP.get();
 
-        int offsetLeft = 10;
-        int height = minecraft.getWindow().getGuiScaledHeight() - 15;
-        int max = mana.getMaxMana();
-        int current = (int) mana.getCurrentMana();
-        String delimiter = renderOnTop ? "/" : "   /   ";
-
-        String textMax = max + delimiter + max;
-        String text = current + delimiter + max;
-
-        int maxWidth = minecraft.font.width(textMax);
         if (renderOnTop) {
-            height -= 25;
-        } else {
-            offsetLeft = 67 - maxWidth / 2;
-        }
-        offsetLeft += maxWidth - minecraft.font.width(text);
+            ArsNouveauAPI.ENABLE_DEBUG_NUMBERS = false;
+            int offsetLeft = 48; //oldvalue = 10
+            int height = minecraft.getWindow().getGuiScaledHeight() - 27; //oldvalue = -40
+            int max = mana.getMaxMana();
+            int current = (int) mana.getCurrentMana();
+            String delimiter = "/";
 
-        drawString(ms, minecraft.font, text, offsetLeft, height, 0xFFFFFF);
-        if (!renderOnTop) {
-            RenderSystem.setShaderTexture(0, new ResourceLocation(ArsNouveau.MODID, "textures/gui/manabar_gui_border" + ".png"));
-            blit(ms, 10, height - 8, 0, 18, 108, 20, 256, 256);
+            String textMax = max + delimiter + max;
+            String text = current + delimiter + max;
+
+            int maxWidth = minecraft.font.width(textMax);
+            offsetLeft += maxWidth - minecraft.font.width(text);
+
+            drawString(ms, minecraft.font, text, offsetLeft, height, 0xFFFFFF);
         }
 
     }
+
 
 }

--- a/src/main/java/de/sarenor/arsinstrumentum/items/ScrollOfSaveStarbuncle.java
+++ b/src/main/java/de/sarenor/arsinstrumentum/items/ScrollOfSaveStarbuncle.java
@@ -16,6 +16,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -42,6 +43,7 @@ public class ScrollOfSaveStarbuncle extends ModItem {
             if (configTag.contains(DATA_TAG)) {
                 starbuncle.data = new Starbuncle.StarbuncleData(configTag.getCompound(DATA_TAG));
             }
+            // consider cherry-picking the data we want to restore
             starbuncle.restoreFromTag();
             if (player != null) {
                 PortUtil.sendMessage(player, Component.literal(APPLIED_CONFIGURATION));
@@ -50,7 +52,7 @@ public class ScrollOfSaveStarbuncle extends ModItem {
     }
 
     @Override
-    public InteractionResult interactLivingEntity(ItemStack doNotUseStack, Player playerEntity, LivingEntity target, InteractionHand hand) {
+    public @NotNull InteractionResult interactLivingEntity(@NotNull ItemStack doNotUseStack, Player playerEntity, @NotNull LivingEntity target, @NotNull InteractionHand hand) {
         if (playerEntity.level.isClientSide || hand != InteractionHand.MAIN_HAND) {
             return InteractionResult.PASS;
         }
@@ -68,7 +70,7 @@ public class ScrollOfSaveStarbuncle extends ModItem {
     }
 
     @Override
-    public InteractionResultHolder<ItemStack> use(Level pLevel, Player playerEntity, InteractionHand hand) {
+    public @NotNull InteractionResultHolder<ItemStack> use(@NotNull Level pLevel, Player playerEntity, @NotNull InteractionHand hand) {
         if (playerEntity.isShiftKeyDown() && hand == InteractionHand.MAIN_HAND) {
             clear(playerEntity.getItemInHand(hand), playerEntity);
         }
@@ -91,10 +93,11 @@ public class ScrollOfSaveStarbuncle extends ModItem {
     private void store(ItemStack scroll, Starbuncle starbuncle, Player player) {
         CompoundTag scrollTag = scroll.getOrCreateTag();
         CompoundTag configTag = new CompoundTag();
-        CompoundTag starbyBehavior = starbuncle.data.toTag(starbuncle, new CompoundTag());
+        Starbuncle.StarbuncleData data = starbuncle.data;
+        CompoundTag starbyBehavior = data.toTag(starbuncle, new CompoundTag());
+        //don't save cosmetic data
+        starbyBehavior.remove("cosmetic");
         configTag.put(DATA_TAG, starbyBehavior);
-        //configTag.putString(TOOLTIP, "Stored Config with " + starbuncle.data.size() + " Take-Locations and "
-        //        + starbuncle.data.TO_LIST.size() + " Deposit-Locations");
         scrollTag.put(SCROLL_OF_SAVE_TAG_ID, configTag);
         scroll.setTag(scrollTag);
         PortUtil.sendMessage(player, Component.literal(SAVED_CONFIGURATION));

--- a/src/main/java/de/sarenor/arsinstrumentum/items/curios/NumericCharm.java
+++ b/src/main/java/de/sarenor/arsinstrumentum/items/curios/NumericCharm.java
@@ -1,10 +1,14 @@
 package de.sarenor.arsinstrumentum.items.curios;
 
+import com.hollingsworth.arsnouveau.api.ArsNouveauAPI;
 import com.hollingsworth.arsnouveau.api.item.ArsNouveauCurio;
+import de.sarenor.arsinstrumentum.setup.ArsInstrumentumConfig;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.SlotContext;
 
 public class NumericCharm extends ArsNouveauCurio {
     public NumericCharm(Properties pProperties) {
@@ -30,4 +34,15 @@ public class NumericCharm extends ArsNouveauCurio {
         return false;
     }
 
+    @Override
+    public void onEquip(SlotContext slotContext, ItemStack prevStack, ItemStack stack) {
+        super.onEquip(slotContext, prevStack, stack);
+        ArsNouveauAPI.ENABLE_DEBUG_NUMBERS = true;
+    }
+
+    @Override
+    public void onUnequip(SlotContext slotContext, ItemStack newStack, ItemStack stack) {
+        super.onUnequip(slotContext, newStack, stack);
+        ArsNouveauAPI.ENABLE_DEBUG_NUMBERS = ArsInstrumentumConfig.Client.SHOW_MANA_NUM.get();
+    }
 }

--- a/src/main/java/de/sarenor/arsinstrumentum/mixins/GlyphCostMixin.java
+++ b/src/main/java/de/sarenor/arsinstrumentum/mixins/GlyphCostMixin.java
@@ -3,6 +3,7 @@ package de.sarenor.arsinstrumentum.mixins;
 import com.hollingsworth.arsnouveau.ArsNouveau;
 import com.hollingsworth.arsnouveau.api.item.ICasterTool;
 import com.hollingsworth.arsnouveau.api.spell.Spell;
+import com.hollingsworth.arsnouveau.api.util.ManaUtil;
 import com.hollingsworth.arsnouveau.common.enchantment.EnchantmentRegistry;
 import com.hollingsworth.arsnouveau.common.items.Glyph;
 import com.hollingsworth.arsnouveau.common.spell.casters.ReactiveCaster;
@@ -35,17 +36,17 @@ public class GlyphCostMixin {
         Player player = ArsNouveau.proxy.getPlayer();
         if (player == null) return;
         if (NumericCharm.hasCharm(player) || ArsInstrumentumConfig.Client.SHOW_MANA_NUM.get()) {
-            int cost = 0;
+            int cost;
             if (instance instanceof Glyph glyph) cost = glyph.spellPart.getCastingCost();
             else if (instance instanceof ICasterTool casterTool) {
                 var casterData = casterTool.getSpellCaster(stack);
                 Spell spell = casterData.getSpell(casterData.getCurrentSlot());
                 if (spell.isEmpty()) return;
-                cost = spell.getDiscountedCost();
+                cost = spell.getDiscountedCost() - ManaUtil.getPlayerDiscounts(player, spell);
             } else if (stack.getEnchantmentLevel(EnchantmentRegistry.REACTIVE_ENCHANTMENT.get()) > 0) {
-                var casterData = new ReactiveCaster(stack).getSpell();
+                Spell casterData = new ReactiveCaster(stack).getSpell();
                 if (casterData.isEmpty()) return;
-                cost = casterData.getDiscountedCost();
+                cost = casterData.getDiscountedCost() - ManaUtil.getPlayerDiscounts(player, casterData);
             } else return;
 
             pTooltipComponents.add(Component.translatable(NumericCharm.TOOLTIP_MESSAGE, cost).setStyle(Style.EMPTY.withColor(ChatFormatting.DARK_PURPLE)).append(String.valueOf(cost)));


### PR DESCRIPTION
- Switch from Instrumentum render text to use native Ars debug numbers, allowing to show up in spellcrafting bar
- Cost in tooltips now account for discounts
- RenderOnTop option won't show spellcrafting bar cost. Numbers have also been moved a bit, old offset is commented for quick restore.
- Scroll of Starbuncle shouldn't duplicate cosmetics anymore